### PR TITLE
Add a cargo feature for not using Send/Sync and threads

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,67 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: check rustfmt
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt
+    - name: Format
+      run: cargo fmt --check
+
+  clippy:
+    name: check clippy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
+    - name: Clippy
+      run: cargo clippy -- -D warnings
+
+  miri:
+    name: test miri
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: miri
+    - name: Miri
+      run: cargo miri test
+
+  tests:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            host_target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            host_target: x86_64-apple-darwin
+          - os: windows-latest
+            host_target: i686-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        path: "dir with spaces/ui test"
+    - uses: dtolnay/rust-toolchain@stable
+    - name: Build
+      run: cargo build --verbose
+    - name: Run unit tests
+      run: cargo test --all-targets --verbose
+    - name: Run unit tests with all features
+      run: cargo test --all-targets --verbose --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,11 @@ edition = "2021"
 
 [dependencies]
 bimap = "0.6.3"
-rayon = "1.10.0"
+rayon = { version = "1.10.0", optional = true }
 thunderdome = "0.6.1"
+
+[features]
+multithreaded = ["rayon"]
 
 [dev-dependencies]
 macroquad = "0.4.13"

--- a/examples/macroquad.rs
+++ b/examples/macroquad.rs
@@ -2,36 +2,36 @@ use macroquad::{prelude::*, rand, ui::root_ui};
 use secs::prelude::{ExecutionMode, World};
 
 struct GameState {
-    paused: bool
+    paused: bool,
 }
 
 struct Position {
     x: f32,
-    y: f32
+    y: f32,
 }
 
 struct Velocity {
     x: f32,
-    y: f32
+    y: f32,
 }
 
 struct Sprite {
     shape: Shape,
     width: f32,
-    height: f32
+    height: f32,
 }
 
 struct Powerup {
-    active: bool
+    active: bool,
 }
 
 struct Score {
-    value: i32
+    value: i32,
 }
 
 enum Shape {
     Square,
-    Circle
+    Circle,
 }
 
 fn move_system(world: &World) {
@@ -67,9 +67,7 @@ fn collision_system(world: &World) {
     for (_, (player_pos, player_spr, player_score)) in
         world.query::<(&Position, &mut Sprite, &mut Score)>()
     {
-        for (_, (powerup_pos, powerup)) in
-            world.query::<(&Position, &mut Powerup)>()
-        {
+        for (_, (powerup_pos, powerup)) in world.query::<(&Position, &mut Powerup)>() {
             if powerup.active
                 && (powerup_pos.x - player_pos.x).abs() < player_spr.width
                 && (powerup_pos.y - player_pos.y).abs() < player_spr.height
@@ -78,7 +76,7 @@ fn collision_system(world: &World) {
 
                 player_spr.shape = match player_spr.shape {
                     Shape::Square => Shape::Circle,
-                    Shape::Circle => Shape::Square
+                    Shape::Circle => Shape::Square,
                 };
 
                 player_score.value += 1;
@@ -105,13 +103,13 @@ fn render_system(world: &World) {
 
     for (_, (pos, sprite)) in world.query::<(&Position, &Sprite)>() {
         match sprite.shape {
-            Shape::Square => draw_rectangle(
-                pos.x, pos.y, sprite.width, sprite.height, ORANGE
-            ),
+            Shape::Square => draw_rectangle(pos.x, pos.y, sprite.width, sprite.height, ORANGE),
             Shape::Circle => draw_circle(
-                pos.x + sprite.width / 2., pos.y + sprite.height / 2.,
-                sprite.width / 2., PURPLE
-            )
+                pos.x + sprite.width / 2.,
+                pos.y + sprite.height / 2.,
+                sprite.width / 2.,
+                PURPLE,
+            ),
         }
     }
 
@@ -133,8 +131,12 @@ async fn main() {
     world.spawn((
         Position { x: 100., y: 100. },
         Velocity { x: 0., y: 0. },
-        Sprite { shape: Shape::Circle, width: 20., height: 20. },
-        Score { value: 0 }
+        Sprite {
+            shape: Shape::Circle,
+            width: 20.,
+            height: 20.,
+        },
+        Score { value: 0 },
     ));
 
     for _ in 0..50 {

--- a/examples/macroquad.rs
+++ b/examples/macroquad.rs
@@ -148,9 +148,16 @@ async fn main() {
 
     world.add_resource(GameState { paused: false });
 
-    // macroquad is single threaded so any systems executng it's code cannot be run in parallel
+    // macroquad is single threaded so any systems executing its code cannot be run in parallel
     world.add_system(move_system, ExecutionMode::Serial);
-    world.add_system(collision_system, ExecutionMode::Parallel);
+    #[cfg(feature = "multithreaded")]
+    {
+        world.add_system(collision_system, ExecutionMode::Parallel);
+    }
+    #[cfg(not(feature = "multithreaded"))]
+    {
+        world.add_system(collision_system, ExecutionMode::Serial);
+    }
     world.add_system(render_system, ExecutionMode::Serial);
 
     loop {

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,25 +1,23 @@
-use crate::world::{Entity, World};
+use crate::world::{Entity, SendSync, World};
 
 pub trait AttachComponents {
     fn attach_to_entity(self, world: &mut World, entity: Entity);
 }
 
-impl<C1: 'static + Send + Sync> AttachComponents for (C1,) {
+impl<C1: SendSync> AttachComponents for (C1,) {
     fn attach_to_entity(self, world: &mut World, entity: Entity) {
         world.attach_component(entity, self.0);
     }
 }
 
-impl<C1: 'static + Send + Sync, C2: 'static + Send + Sync> AttachComponents for (C1, C2) {
+impl<C1: SendSync, C2: SendSync> AttachComponents for (C1, C2) {
     fn attach_to_entity(self, world: &mut World, entity: Entity) {
         world.attach_component(entity, self.0);
         world.attach_component(entity, self.1);
     }
 }
 
-impl<C1: 'static + Send + Sync, C2: 'static + Send + Sync, C3: 'static + Send + Sync>
-    AttachComponents for (C1, C2, C3)
-{
+impl<C1: SendSync, C2: SendSync, C3: SendSync> AttachComponents for (C1, C2, C3) {
     fn attach_to_entity(self, world: &mut World, entity: Entity) {
         world.attach_component(entity, self.0);
         world.attach_component(entity, self.1);
@@ -27,13 +25,7 @@ impl<C1: 'static + Send + Sync, C2: 'static + Send + Sync, C3: 'static + Send + 
     }
 }
 
-impl<
-        C1: 'static + Send + Sync,
-        C2: 'static + Send + Sync,
-        C3: 'static + Send + Sync,
-        C4: 'static + Send + Sync,
-    > AttachComponents for (C1, C2, C3, C4)
-{
+impl<C1: SendSync, C2: SendSync, C3: SendSync, C4: SendSync> AttachComponents for (C1, C2, C3, C4) {
     fn attach_to_entity(self, world: &mut World, entity: Entity) {
         world.attach_component(entity, self.0);
         world.attach_component(entity, self.1);
@@ -42,13 +34,8 @@ impl<
     }
 }
 
-impl<
-        C1: 'static + Send + Sync,
-        C2: 'static + Send + Sync,
-        C3: 'static + Send + Sync,
-        C4: 'static + Send + Sync,
-        C5: 'static + Send + Sync,
-    > AttachComponents for (C1, C2, C3, C4, C5)
+impl<C1: SendSync, C2: SendSync, C3: SendSync, C4: SendSync, C5: SendSync> AttachComponents
+    for (C1, C2, C3, C4, C5)
 {
     fn attach_to_entity(self, world: &mut World, entity: Entity) {
         world.attach_component(entity, self.0);

--- a/src/components.rs
+++ b/src/components.rs
@@ -17,11 +17,9 @@ impl<C1: 'static + Send + Sync, C2: 'static + Send + Sync> AttachComponents for 
     }
 }
 
-impl<
-    C1: 'static + Send + Sync,
-    C2: 'static + Send + Sync,
-    C3: 'static + Send + Sync
-> AttachComponents for (C1, C2, C3) {
+impl<C1: 'static + Send + Sync, C2: 'static + Send + Sync, C3: 'static + Send + Sync>
+    AttachComponents for (C1, C2, C3)
+{
     fn attach_to_entity(self, world: &mut World, entity: Entity) {
         world.attach_component(entity, self.0);
         world.attach_component(entity, self.1);
@@ -30,11 +28,12 @@ impl<
 }
 
 impl<
-    C1: 'static + Send + Sync,
-    C2: 'static + Send + Sync,
-    C3: 'static + Send + Sync,
-    C4: 'static + Send + Sync
-> AttachComponents for (C1, C2, C3, C4) {
+        C1: 'static + Send + Sync,
+        C2: 'static + Send + Sync,
+        C3: 'static + Send + Sync,
+        C4: 'static + Send + Sync,
+    > AttachComponents for (C1, C2, C3, C4)
+{
     fn attach_to_entity(self, world: &mut World, entity: Entity) {
         world.attach_component(entity, self.0);
         world.attach_component(entity, self.1);
@@ -44,12 +43,13 @@ impl<
 }
 
 impl<
-    C1: 'static + Send + Sync,
-    C2: 'static + Send + Sync,
-    C3: 'static + Send + Sync,
-    C4: 'static + Send + Sync,
-    C5: 'static + Send + Sync
-> AttachComponents for (C1, C2, C3, C4, C5) {
+        C1: 'static + Send + Sync,
+        C2: 'static + Send + Sync,
+        C3: 'static + Send + Sync,
+        C4: 'static + Send + Sync,
+        C5: 'static + Send + Sync,
+    > AttachComponents for (C1, C2, C3, C4, C5)
+{
     fn attach_to_entity(self, world: &mut World, entity: Entity) {
         world.attach_component(entity, self.0);
         world.attach_component(entity, self.1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
+mod components;
 mod query;
 mod scheduler;
 mod sparse_set;
 mod world;
-mod components;
 
 pub mod prelude {
-    pub use super::world::{Entity, World};
     pub use super::scheduler::ExecutionMode;
+    pub use super::world::{Entity, World};
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,14 +1,14 @@
 use crate::world::{Entity, World, WorldQuery};
 
 pub trait Query<'a> {
-    fn get_components(world: &'a World) -> Option<impl Iterator<Item = (Entity, Self)> + 'a>; 
+    fn get_components(world: &'a World) -> Option<impl Iterator<Item = (Entity, Self)> + 'a>;
 }
 
 impl<'a, C: 'static> Query<'a> for (&'a C,) {
     fn get_components(world: &'a World) -> Option<impl Iterator<Item = (Entity, Self)> + 'a> {
-        world.get_sparse_set::<C>().map(|set| {
-            set.iter().map(|(entity, component)| (entity, (component,)))
-        })
+        world
+            .get_sparse_set::<C>()
+            .map(|set| set.iter().map(|(entity, component)| (entity, (component,))))
     }
 }
 
@@ -21,7 +21,7 @@ impl<'a, C1: 'static, C2: 'static> Query<'a> for (&'a C1, &'a C2) {
             s2.get(entity).map(|_| {
                 let idx2 = s2.get(entity).unwrap();
                 let c2 = &s2.dense[*idx2];
-                
+
                 (entity, (c1, c2))
             })
         }))
@@ -31,7 +31,8 @@ impl<'a, C1: 'static, C2: 'static> Query<'a> for (&'a C1, &'a C2) {
 impl<'a, C: 'static> Query<'a> for (&'a mut C,) {
     fn get_components(world: &'a World) -> Option<impl Iterator<Item = (Entity, Self)> + 'a> {
         world.get_sparse_set_mut::<C>().map(|set| {
-            set.iter_mut().map(|(entity, component)| (entity, (component,)))
+            set.iter_mut()
+                .map(|(entity, component)| (entity, (component,)))
         })
     }
 }
@@ -61,7 +62,7 @@ impl<'a, C1: 'static, C2: 'static> Query<'a> for (&'a C1, &'a mut C2) {
 
         Some(s1.iter().filter_map(move |(entity, c1)| {
             let idx2 = s2.get(entity)?;
-            
+
             Some((entity, (c1, unsafe { &mut *dense2.add(*idx2) })))
         }))
     }
@@ -75,7 +76,7 @@ impl<'a, C1: 'static, C2: 'static> Query<'a> for (&'a mut C1, &'a C2) {
 
         Some(s2.iter().filter_map(move |(entity, c2)| {
             let idx1 = s1.get(entity)?;
-            
+
             Some((entity, (unsafe { &mut *dense1.add(*idx1) }, c2)))
         }))
     }
@@ -109,11 +110,13 @@ impl<'a, C1: 'static, C2: 'static, C3: 'static> Query<'a> for (&'a mut C1, &'a m
             let idx2 = s2.get(entity)?;
             let idx3 = s3.get(entity)?;
 
-            Some((entity, unsafe {(
-                &mut *dense1.add(idx1),
-                &mut *dense2.add(*idx2),
-                &mut *dense3.add(*idx3)
-            )}))
+            Some((entity, unsafe {
+                (
+                    &mut *dense1.add(idx1),
+                    &mut *dense2.add(*idx2),
+                    &mut *dense3.add(*idx3),
+                )
+            }))
         }))
     }
 }
@@ -200,7 +203,9 @@ impl<'a, C1: 'static, C2: 'static, C3: 'static> Query<'a> for (&'a mut C1, &'a C
             let idx1 = s1.get(entity)?;
             let idx3 = s3.get(entity)?;
 
-            Some((entity, unsafe { (&mut *dense1.add(*idx1), c2, &mut *dense3.add(*idx3)) }))
+            Some((entity, unsafe {
+                (&mut *dense1.add(*idx1), c2, &mut *dense3.add(*idx3))
+            }))
         }))
     }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -24,7 +24,7 @@ impl Scheduler {
         if let Some(pos) = self
             .systems
             .iter()
-            .position(|(s, _)| s as *const _ == system as *const _)
+            .position(|(s, _)| *s as *const _ == system as *const _)
         {
             self.systems.remove(pos);
         }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -7,12 +7,12 @@ pub type System = fn(&World);
 #[derive(PartialEq)]
 pub enum ExecutionMode {
     Parallel,
-    Serial
+    Serial,
 }
 
 #[derive(Default)]
 pub struct Scheduler {
-    systems: Vec<(System, ExecutionMode)>
+    systems: Vec<(System, ExecutionMode)>,
 }
 
 impl Scheduler {
@@ -21,7 +21,8 @@ impl Scheduler {
     }
 
     pub(crate) fn deregister(&mut self, system: System) {
-        if let Some(pos) = self.systems
+        if let Some(pos) = self
+            .systems
             .iter()
             .position(|(s, _)| s as *const _ == system as *const _)
         {
@@ -30,11 +31,13 @@ impl Scheduler {
     }
 
     pub(crate) fn run(&self, world: &World) {
-        self.systems.par_iter()
-        .filter(|(_, mode)| *mode == ExecutionMode::Parallel)
-        .for_each(|(sys, _)| sys(world));
+        self.systems
+            .par_iter()
+            .filter(|(_, mode)| *mode == ExecutionMode::Parallel)
+            .for_each(|(sys, _)| sys(world));
 
-        self.systems.iter()
+        self.systems
+            .iter()
             .filter(|(_, mode)| *mode == ExecutionMode::Serial)
             .for_each(|(sys, _)| sys(world));
     }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -26,7 +26,7 @@ impl Scheduler {
         if let Some(pos) = self
             .systems
             .iter()
-            .position(|(s, _)| *s as *const () == system as *const ())
+            .position(|(s, _)| std::ptr::fn_addr_eq(*s, system))
         {
             self.systems.remove(pos);
         }

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,8 +1,16 @@
-use std::{any::{Any, TypeId}, collections::HashMap};
+use std::{
+    any::{Any, TypeId},
+    collections::HashMap,
+};
 
 use thunderdome::{Arena, Index};
 
-use crate::{components::AttachComponents, query::Query, scheduler::{ExecutionMode, Scheduler, System}, sparse_set::{SparseSet, SparseSets}};
+use crate::{
+    components::AttachComponents,
+    query::Query,
+    scheduler::{ExecutionMode, Scheduler, System},
+    sparse_set::{SparseSet, SparseSets},
+};
 
 pub type Entity = Index;
 
@@ -11,11 +19,15 @@ pub struct World {
     entities: Arena<()>,
     sparse_sets: SparseSets,
     scheduler: Scheduler,
-    resources: HashMap<TypeId, Box<dyn Any + Send + Sync>>
+    resources: HashMap<TypeId, Box<dyn Any + Send + Sync>>,
 }
 
 impl World {
-    pub(crate) fn attach_component<C: 'static + Send + Sync>(&mut self, entity: Entity, component: C) {
+    pub(crate) fn attach_component<C: 'static + Send + Sync>(
+        &mut self,
+        entity: Entity,
+        component: C,
+    ) {
         if let Some(set) = self.sparse_sets.get_mut::<C>() {
             set.insert(entity, component);
         } else {
@@ -34,7 +46,9 @@ impl World {
     }
 
     pub fn detach<C: 'static>(&mut self, entity: Entity) {
-        self.sparse_sets.get_mut::<C>().map(|set| set.remove(entity));
+        self.sparse_sets
+            .get_mut::<C>()
+            .map(|set| set.remove(entity));
     }
 
     pub fn query<'a, Q: Query<'a>>(&'a self) -> impl Iterator<Item = (thunderdome::Index, Q)> + 'a {
@@ -46,11 +60,15 @@ impl World {
     }
 
     pub fn get_resource<R: 'static>(&self) -> Option<&R> {
-        self.resources.get(&TypeId::of::<R>()).and_then(|r| r.downcast_ref())
+        self.resources
+            .get(&TypeId::of::<R>())
+            .and_then(|r| r.downcast_ref())
     }
 
     pub fn get_resource_mut<R: 'static>(&mut self) -> Option<&mut R> {
-        self.resources.get_mut(&TypeId::of::<R>()).and_then(|r| r.downcast_mut())
+        self.resources
+            .get_mut(&TypeId::of::<R>())
+            .and_then(|r| r.downcast_mut())
     }
 
     pub fn remove_resource<R: 'static>(&mut self) {

--- a/src/world.rs
+++ b/src/world.rs
@@ -54,9 +54,9 @@ impl World {
     }
 
     pub fn detach<C: 'static>(&mut self, entity: Entity) {
-        self.sparse_sets
-            .get_mut::<C>()
-            .map(|set| set.remove(entity));
+        if let Some(set) = self.sparse_sets.get_mut::<C>() {
+            set.remove(entity)
+        }
     }
 
     pub fn query<'a, Q: Query<'a>>(&'a self) -> impl Iterator<Item = (thunderdome::Index, Q)> + 'a {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -1,0 +1,15 @@
+use std::panic::AssertUnwindSafe;
+
+use secs::prelude::*;
+
+#[test]
+fn remove() {
+    let mut world = World::default();
+    fn boom(_: &World) {
+        panic!()
+    }
+    world.add_system(boom, ExecutionMode::Serial);
+    assert!(std::panic::catch_unwind(AssertUnwindSafe(|| world.run_systems())).is_err());
+    world.remove_system(boom);
+    world.run_systems();
+}


### PR DESCRIPTION
I want to put https://github.com/oli-obk/layer-proc-gen into a resource, and since I've given up on multithreading anyway for now due to wasm not supporting it and it being a pain in layer-proc-gen...

It's not fully an additive cargo feature, as existing code that uses non-`Send+Sync` types will break when the feature is enabled.