### PR TITLE
Add mutable systems

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,9 +1,12 @@
 #[cfg(feature = "multithreaded")]
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+use std::sync::{Arc, RwLock};
 
 use crate::world::World;
 
 pub type System = fn(&World);
+pub type MutSystem = fn(&mut World);
 
 #[derive(PartialEq)]
 pub enum ExecutionMode {
@@ -12,42 +15,85 @@ pub enum ExecutionMode {
     Serial,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Scheduler {
-    systems: Vec<(System, ExecutionMode)>,
+    #[cfg(feature = "multithreaded")]
+    parallel_systems: Arc<RwLock<Vec<System>>>,
+    systems: Arc<RwLock<Vec<MutSystem>>>,
 }
 
 impl Scheduler {
+    pub(crate) fn register_mut(&mut self, system: MutSystem) {
+        self.systems.write().unwrap().push(system)
+    }
+
     pub(crate) fn register(&mut self, system: System, mode: ExecutionMode) {
-        self.systems.push((system, mode));
+        match mode {
+            // SAFETY: a `fn(&World)` is always safe to use as a `fn(&mut World)`, Rust just doesn't support that safely.
+            ExecutionMode::Serial => self
+                .systems
+                .write()
+                .unwrap()
+                .push(unsafe { std::mem::transmute::<System, MutSystem>(system) }),
+            #[cfg(feature = "multithreaded")]
+            ExecutionMode::Parallel => self.parallel_systems.write().unwrap().push(system),
+        }
     }
 
     pub(crate) fn deregister(&mut self, system: System) {
-        if let Some(pos) = self
+        #[expect(clippy::ptr_eq)]
+        let position = self
             .systems
+            .read()
+            .unwrap()
             .iter()
-            .position(|(s, _)| std::ptr::fn_addr_eq(*s, system))
-        {
-            self.systems.remove(pos);
+            .position(|&s| s as *const () == system as *const _);
+        if let Some(pos) = position {
+            let _ = self.systems.write().unwrap().remove(pos);
+            #[cfg(feature = "multithreaded")]
+            return;
+        }
+        #[cfg(feature = "multithreaded")]
+        #[expect(unpredictable_function_pointer_comparisons)]
+        let position = self
+            .parallel_systems
+            .read()
+            .unwrap()
+            .iter()
+            .position(|&s| s == system);
+        #[cfg(feature = "multithreaded")]
+        if let Some(pos) = position {
+            let _ = self.parallel_systems.write().unwrap().remove(pos);
         }
     }
 
-    pub(crate) fn run(&self, world: &World) {
-        #[cfg(feature = "multithreaded")]
-        {
-            self.systems
-                .par_iter()
-                .filter(|(_, mode)| *mode == ExecutionMode::Parallel)
-                .for_each(|(sys, _)| sys(world));
+    pub(crate) fn deregister_mut(&mut self, system: MutSystem) {
+        #[expect(unpredictable_function_pointer_comparisons)]
+        let position = self
+            .systems
+            .read()
+            .unwrap()
+            .iter()
+            .position(|&s| s == system);
+        if let Some(pos) = position {
+            let _ = self.systems.write().unwrap().remove(pos);
+        }
+    }
 
-            self.systems
-                .iter()
-                .filter(|(_, mode)| *mode == ExecutionMode::Serial)
-                .for_each(|(sys, _)| sys(world));
-        }
-        #[cfg(not(feature = "multithreaded"))]
-        {
-            self.systems.iter().for_each(|(sys, _)| sys(world));
-        }
+    pub(crate) fn run(&self, world: &mut World) {
+        #[cfg(feature = "multithreaded")]
+        let len = self.parallel_systems.read().unwrap().len();
+        #[cfg(feature = "multithreaded")]
+        let systems = &self.parallel_systems;
+        #[cfg(feature = "multithreaded")]
+        (0..len)
+            .into_par_iter()
+            .filter_map(|i| systems.read().unwrap().get(i).copied())
+            .for_each(|sys| sys(world));
+
+        let len = self.systems.read().unwrap().len();
+        (0..len)
+            .filter_map(|i| self.systems.read().unwrap().get(i).copied())
+            .for_each(|sys| sys(world));
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -8,7 +8,7 @@ use thunderdome::{Arena, Index};
 use crate::{
     components::AttachComponents,
     query::Query,
-    scheduler::{ExecutionMode, Scheduler, System},
+    scheduler::{ExecutionMode, MutSystem, Scheduler, System},
     sparse_set::{SparseSet, SparseSets},
 };
 
@@ -87,12 +87,22 @@ impl World {
         self.scheduler.register(system, mode);
     }
 
+    pub fn add_mut_system(&mut self, system: MutSystem) {
+        self.scheduler.register_mut(system);
+    }
+
     pub fn remove_system(&mut self, system: System) {
         self.scheduler.deregister(system);
     }
 
-    pub fn run_systems(&self) {
-        self.scheduler.run(self);
+    pub fn remove_mut_system(&mut self, system: MutSystem) {
+        self.scheduler.deregister_mut(system);
+    }
+
+    pub fn run_systems(&mut self) {
+        // Shallow clone, everything is reference counted inside
+        let scheduler = self.scheduler.clone();
+        scheduler.run(self);
     }
 }
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -17,3 +17,26 @@ fn remove() {
     world.remove_system(boom);
     world.run_systems();
 }
+
+#[test]
+fn remove_within() {
+    let mut world = World::default();
+    fn boom(_: &World) {
+        panic!()
+    }
+    // Miri will assume every time you mention a function you could have a new address
+    // While this is bogus in many cases, it's the only way to catch the rare cases where
+    // it's an issue. So we do this provenance preserving deduplication by eagerly creating a pointer.
+    let boom = boom as fn(&World);
+    world.add_resource(boom);
+
+    fn defuse(world: &mut World) {
+        let boom = *world.get_resource::<fn(&World)>().unwrap();
+        // Remove the boom system. Since we run before it, it will never actuall run, yay.
+        world.remove_system(boom);
+    }
+
+    world.add_mut_system(defuse);
+    world.add_system(boom, ExecutionMode::Serial);
+    world.run_systems();
+}


### PR DESCRIPTION
Systems should be able to create new entities (and even systems?). This isn't too hard to do without threads, but fairly annoying with threads.

One major issue with this implementation is that you can't remove systems from *within* other systems, and I'm not sure how to fix that:

* could maintain a list of systems to remove to be actually removed after all systems ran
    * good: only pay a cost when removing things
    * unsure: may run a removed system one more time if it is after the system that is removing the other one
* make the system list `Arc<RwLock<Vec<System>>>` so that we always have one list
    * good: a removed system will not ever be run again
    * bad: need to read lock and take out a single system by index every time we move to a new system

I'm somewhat tending to the second one, the cost should be negligible.

Thoughts? 