### PR TITLE
Fix unsoundness in queries

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ jobs:
       with:
         components: miri
     - name: Miri
-      run: cargo miri test
+      run: env MIRIFLAGS="-Zmiri-tree-borrows" cargo miri test
 
   tests:
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
 name = "bytemuck"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +172,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "macroquad"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,12 +264,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -305,11 +344,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "secs"
 version = "0.1.0"
 dependencies = [
  "bimap",
  "macroquad",
+ "parking_lot",
  "rayon",
  "thunderdome",
 ]
@@ -328,6 +383,12 @@ checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "syn"
@@ -385,6 +446,70 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "secs"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 bimap = "0.6.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 bimap = "0.6.3"
+parking_lot = "0.12.3"
 rayon = { version = "1.10.0", optional = true }
 thunderdome = "0.6.1"
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -18,9 +18,8 @@ impl<'a, C1: 'static, C2: 'static> Query<'a> for (&'a C1, &'a C2) {
         let s2 = world.get_sparse_set::<C2>()?;
 
         Some(s1.iter().filter_map(|(entity, c1)| {
-            s2.get(entity).map(|_| {
-                let idx2 = s2.get(entity).unwrap();
-                let c2 = &s2.dense[*idx2];
+            s2.get(entity).map(|idx2| {
+                let c2 = &s2.dense[idx2];
 
                 (entity, (c1, c2))
             })
@@ -48,7 +47,7 @@ impl<'a, C1: 'static, C2: 'static> Query<'a> for (&'a mut C1, &'a mut C2) {
             let idx2 = s2.get(entity)?;
 
             Some((entity, unsafe {
-                (&mut *dense1.add(idx1), &mut *dense2.add(*idx2))
+                (&mut *dense1.add(idx1), &mut *dense2.add(idx2))
             }))
         }))
     }
@@ -63,7 +62,7 @@ impl<'a, C1: 'static, C2: 'static> Query<'a> for (&'a C1, &'a mut C2) {
         Some(s1.iter().filter_map(move |(entity, c1)| {
             let idx2 = s2.get(entity)?;
 
-            Some((entity, (c1, unsafe { &mut *dense2.add(*idx2) })))
+            Some((entity, (c1, unsafe { &mut *dense2.add(idx2) })))
         }))
     }
 }
@@ -77,7 +76,7 @@ impl<'a, C1: 'static, C2: 'static> Query<'a> for (&'a mut C1, &'a C2) {
         Some(s2.iter().filter_map(move |(entity, c2)| {
             let idx1 = s1.get(entity)?;
 
-            Some((entity, (unsafe { &mut *dense1.add(*idx1) }, c2)))
+            Some((entity, (unsafe { &mut *dense1.add(idx1) }, c2)))
         }))
     }
 }
@@ -89,8 +88,8 @@ impl<'a, C1: 'static, C2: 'static, C3: 'static> Query<'a> for (&'a C1, &'a C2, &
         let s3 = world.get_sparse_set::<C3>()?;
 
         Some(s1.iter().filter_map(move |(entity, c1)| {
-            let c2 = s2.get(entity).and_then(|&idx| s2.dense.get(idx))?;
-            let c3 = s3.get(entity).and_then(|&idx| s3.dense.get(idx))?;
+            let c2 = s2.get(entity).and_then(|idx| s2.dense.get(idx))?;
+            let c3 = s3.get(entity).and_then(|idx| s3.dense.get(idx))?;
 
             Some((entity, (c1, c2, c3)))
         }))
@@ -113,8 +112,8 @@ impl<'a, C1: 'static, C2: 'static, C3: 'static> Query<'a> for (&'a mut C1, &'a m
             Some((entity, unsafe {
                 (
                     &mut *dense1.add(idx1),
-                    &mut *dense2.add(*idx2),
-                    &mut *dense3.add(*idx3),
+                    &mut *dense2.add(idx2),
+                    &mut *dense3.add(idx3),
                 )
             }))
         }))
@@ -129,10 +128,10 @@ impl<'a, C1: 'static, C2: 'static, C3: 'static> Query<'a> for (&'a mut C1, &'a C
         let dense1 = s1.dense.as_mut_ptr();
 
         Some(s2.iter().filter_map(move |(entity, c2)| {
-            let c3 = s3.get(entity).and_then(|&idx| s3.dense.get(idx))?;
+            let c3 = s3.get(entity).and_then(|idx| s3.dense.get(idx))?;
             let idx1 = s1.get(entity)?;
 
-            Some((entity, unsafe { (&mut *dense1.add(*idx1), c2, c3) }))
+            Some((entity, unsafe { (&mut *dense1.add(idx1), c2, c3) }))
         }))
     }
 }
@@ -150,7 +149,7 @@ impl<'a, C1: 'static, C2: 'static, C3: 'static> Query<'a> for (&'a C1, &'a mut C
             let idx3 = s3.get(entity)?;
 
             Some((entity, unsafe {
-                (c1, &mut *dense2.add(*idx2), &mut *dense3.add(*idx3))
+                (c1, &mut *dense2.add(idx2), &mut *dense3.add(idx3))
             }))
         }))
     }
@@ -169,7 +168,7 @@ impl<'a, C1: 'static, C2: 'static, C3: 'static> Query<'a> for (&'a mut C1, &'a m
             let idx2 = s2.get(entity)?;
 
             Some((entity, unsafe {
-                (&mut *dense1.add(*idx1), &mut *dense2.add(*idx2), c3)
+                (&mut *dense1.add(idx1), &mut *dense2.add(idx2), c3)
             }))
         }))
     }
@@ -183,10 +182,10 @@ impl<'a, C1: 'static, C2: 'static, C3: 'static> Query<'a> for (&'a C1, &'a mut C
         let dense2 = s2.dense.as_mut_ptr();
 
         Some(s1.iter().filter_map(move |(entity, c1)| {
-            let c3 = s3.get(entity).and_then(|&idx| s3.dense.get(idx))?;
+            let c3 = s3.get(entity).and_then(|idx| s3.dense.get(idx))?;
             let idx2 = s2.get(entity)?;
 
-            Some((entity, unsafe { (c1, &mut *dense2.add(*idx2), c3) }))
+            Some((entity, unsafe { (c1, &mut *dense2.add(idx2), c3) }))
         }))
     }
 }
@@ -204,7 +203,7 @@ impl<'a, C1: 'static, C2: 'static, C3: 'static> Query<'a> for (&'a mut C1, &'a C
             let idx3 = s3.get(entity)?;
 
             Some((entity, unsafe {
-                (&mut *dense1.add(*idx1), c2, &mut *dense3.add(*idx3))
+                (&mut *dense1.add(idx1), c2, &mut *dense3.add(idx3))
             }))
         }))
     }
@@ -218,10 +217,10 @@ impl<'a, C1: 'static, C2: 'static, C3: 'static> Query<'a> for (&'a C1, &'a C2, &
         let dense3 = s3.dense.as_mut_ptr();
 
         Some(s1.iter().filter_map(move |(entity, c1)| {
-            let c2 = s2.get(entity).and_then(|&idx| s2.dense.get(idx))?;
+            let c2 = s2.get(entity).and_then(|idx| s2.dense.get(idx))?;
             let idx3 = s3.get(entity)?;
 
-            Some((entity, unsafe { (c1, c2, &mut *dense3.add(*idx3)) }))
+            Some((entity, unsafe { (c1, c2, &mut *dense3.add(idx3)) }))
         }))
     }
 }

--- a/src/sparse_set.rs
+++ b/src/sparse_set.rs
@@ -122,6 +122,7 @@ impl SparseSets {
         );
     }
 
+    #[track_caller]
     pub fn get<C: 'static>(&self) -> Option<MappedRwLockReadGuard<SparseSet<C>>> {
         let set = self.sets.get(&TypeId::of::<C>())?;
         let Some(guard) = set.try_read() else {
@@ -136,6 +137,7 @@ impl SparseSets {
         }))
     }
 
+    #[track_caller]
     pub fn get_mut<C: 'static>(&self) -> Option<MappedRwLockWriteGuard<SparseSet<C>>> {
         let set = self.sets.get(&TypeId::of::<C>())?;
         let Some(guard) = set.try_write() else {

--- a/src/sparse_set.rs
+++ b/src/sparse_set.rs
@@ -41,8 +41,8 @@ impl<C> SparseSet<C> {
         }
     }
 
-    pub fn get(&self, entity: Entity) -> Option<&usize> {
-        self.sparse.get_by_left(&entity)
+    pub fn get(&self, entity: Entity) -> Option<usize> {
+        self.sparse.get_by_left(&entity).copied()
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (Entity, &C)> {

--- a/src/world.rs
+++ b/src/world.rs
@@ -60,8 +60,9 @@ impl World {
         }
     }
 
-    pub fn query<'a, Q: Query<'a>>(&'a self) -> impl Iterator<Item = (thunderdome::Index, Q)> + 'a {
-        Q::get_components(self).into_iter().flatten()
+    #[track_caller]
+    pub fn query<'a, Q: Query<'a>>(&'a self, f: impl for<'b> FnMut(Entity, Q::Short<'b>)) {
+        Q::get_components(self, f)
     }
 
     pub fn add_resource<R: 'static + SendSync>(&mut self, res: R) {
@@ -113,10 +114,12 @@ pub trait WorldQuery {
 }
 
 impl WorldQuery for World {
+    #[track_caller]
     fn get_sparse_set<C: 'static>(&self) -> Option<MappedRwLockReadGuard<SparseSet<C>>> {
         self.sparse_sets.get::<C>()
     }
 
+    #[track_caller]
     fn get_sparse_set_mut<C: 'static>(&self) -> Option<MappedRwLockWriteGuard<SparseSet<C>>> {
         self.sparse_sets.get_mut::<C>()
     }

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1,6 +1,9 @@
 use secs::prelude::*;
 
 #[test]
+#[should_panic(
+    expected = "Tried to access component `u32` mutably, but it was already being written to or read from"
+)]
 fn aliasing_mutation() {
     let mut world = World::default();
 
@@ -8,9 +11,9 @@ fn aliasing_mutation() {
     world.spawn((10_u32,));
 
     // 💥 in miri with stacked borrows
-    for (_, (a, b)) in world.query::<(&mut u32, &mut u32)>() {
+    world.query::<(&mut u32, &mut u32)>(|_, (a, b)| {
         // bad bad bad
         *a = *b;
         *b = *a; // 💥 in miri with tree borrows
-    }
+    });
 }

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1,0 +1,16 @@
+use secs::prelude::*;
+
+#[test]
+fn aliasing_mutation() {
+    let mut world = World::default();
+
+    world.spawn((1_u32,));
+    world.spawn((10_u32,));
+
+    // 💥 in miri with stacked borrows
+    for (_, (a, b)) in world.query::<(&mut u32, &mut u32)>() {
+        // bad bad bad
+        *a = *b;
+        *b = *a; // 💥 in miri with tree borrows
+    }
+}


### PR DESCRIPTION
The lock that was there to protect queries was dropped before returning a reference to the locked content. This in turn allowed a single query to mutably alias its components itself.

I tried fixing this with some cursed type spaghetti, but ultimately failed to produce something that actually compiled (secs compiled, just no one could use the queries).

So I turned everything into closures as dicusssed. It's actually pretty neat to use and makes follow-up usability improvements a lot easier