### PR TITLE
Make panic message point to user code instead of into secs internals

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -52,6 +52,7 @@ pub trait SparseSetGetter<'a> {
 impl<'a, C: 'static> SparseSetGetter<'a> for &'a C {
     type Short<'b> = &'b C;
     type Iter = MappedRwLockReadGuard<'a, SparseSet<C>>;
+    #[track_caller]
     fn get_set(world: &'a World) -> Option<Self::Iter> {
         world.get_sparse_set()
     }
@@ -67,6 +68,7 @@ impl<'a, C: 'static> SparseSetGetter<'a> for &'a C {
 impl<'a, T: SparseSetGetter<'a>> SparseSetGetter<'a> for Option<T> {
     type Short<'b> = Option<T::Short<'b>>;
     type Iter = T::Iter;
+    #[track_caller]
     fn get_set(world: &'a World) -> Option<Self::Iter> {
         T::get_set(world)
     }
@@ -84,6 +86,7 @@ impl<'a, T: SparseSetGetter<'a>> SparseSetGetter<'a> for Option<T> {
 impl<'a, C: 'static> SparseSetGetter<'a> for &'a mut C {
     type Short<'b> = &'b mut C;
     type Iter = MappedRwLockWriteGuard<'a, SparseSet<C>>;
+    #[track_caller]
     fn get_set(world: &'a World) -> Option<Self::Iter> {
         world.get_sparse_set_mut()
     }

--- a/tests/ui/double_mut_borrow_panic.rs
+++ b/tests/ui/double_mut_borrow_panic.rs
@@ -1,0 +1,12 @@
+//@run:101
+
+use secs::prelude::*;
+
+fn main() {
+    let mut world = World::default();
+
+    world.spawn((1_u32,));
+    world.spawn((10_u32,));
+
+    world.query::<(&mut u32, &mut u32)>(|_, (_, _)| {});
+}

--- a/tests/ui/double_mut_borrow_panic.run.stderr
+++ b/tests/ui/double_mut_borrow_panic.run.stderr
@@ -1,0 +1,4 @@
+
+thread 'main' panicked at $DIR/src/query.rs:
+Tried to access component `u32` mutably, but it was already being written to or read from
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/double_mut_borrow_panic.run.stderr
+++ b/tests/ui/double_mut_borrow_panic.run.stderr
@@ -1,4 +1,4 @@
 
-thread 'main' panicked at $DIR/src/query.rs:
+thread 'main' panicked at tests/ui/double_mut_borrow_panic.rs:11:11:
 Tried to access component `u32` mutably, but it was already being written to or read from
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
While this can be extracted from the backtrace, let's not make the user (me, I'm user, I'm lazy) jump through hoops