### PR TITLE
Allow attaching components if their set isn't currently in use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "elsa"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2343daaeabe09879d4ea058bb4f1e63da3fc07dadc6634e01bda1b3d6a9d9d2b"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +747,7 @@ name = "secs"
 version = "0.1.0"
 dependencies = [
  "bimap",
+ "elsa",
  "macroquad",
  "parking_lot",
  "rayon",
@@ -831,6 +841,12 @@ dependencies = [
  "bstr",
  "color-eyre",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 bimap = "0.6.3"
+elsa = "1.11.0"
 parking_lot = "0.12.3"
 rayon = { version = "1.10.0", optional = true }
 thunderdome = "0.6.1"

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,24 +1,24 @@
 use crate::world::{Entity, SendSync, World};
 
 pub trait AttachComponents {
-    fn attach_to_entity(self, world: &mut World, entity: Entity);
+    fn attach_to_entity(self, world: &World, entity: Entity);
 }
 
 impl<C1: SendSync> AttachComponents for (C1,) {
-    fn attach_to_entity(self, world: &mut World, entity: Entity) {
+    fn attach_to_entity(self, world: &World, entity: Entity) {
         world.attach_component(entity, self.0);
     }
 }
 
 impl<C1: SendSync, C2: SendSync> AttachComponents for (C1, C2) {
-    fn attach_to_entity(self, world: &mut World, entity: Entity) {
+    fn attach_to_entity(self, world: &World, entity: Entity) {
         world.attach_component(entity, self.0);
         world.attach_component(entity, self.1);
     }
 }
 
 impl<C1: SendSync, C2: SendSync, C3: SendSync> AttachComponents for (C1, C2, C3) {
-    fn attach_to_entity(self, world: &mut World, entity: Entity) {
+    fn attach_to_entity(self, world: &World, entity: Entity) {
         world.attach_component(entity, self.0);
         world.attach_component(entity, self.1);
         world.attach_component(entity, self.2);
@@ -26,7 +26,7 @@ impl<C1: SendSync, C2: SendSync, C3: SendSync> AttachComponents for (C1, C2, C3)
 }
 
 impl<C1: SendSync, C2: SendSync, C3: SendSync, C4: SendSync> AttachComponents for (C1, C2, C3, C4) {
-    fn attach_to_entity(self, world: &mut World, entity: Entity) {
+    fn attach_to_entity(self, world: &World, entity: Entity) {
         world.attach_component(entity, self.0);
         world.attach_component(entity, self.1);
         world.attach_component(entity, self.2);
@@ -37,7 +37,7 @@ impl<C1: SendSync, C2: SendSync, C3: SendSync, C4: SendSync> AttachComponents fo
 impl<C1: SendSync, C2: SendSync, C3: SendSync, C4: SendSync, C5: SendSync> AttachComponents
     for (C1, C2, C3, C4, C5)
 {
-    fn attach_to_entity(self, world: &mut World, entity: Entity) {
+    fn attach_to_entity(self, world: &World, entity: Entity) {
         world.attach_component(entity, self.0);
         world.attach_component(entity, self.1);
         world.attach_component(entity, self.2);

--- a/src/sparse_set.rs
+++ b/src/sparse_set.rs
@@ -127,14 +127,14 @@ impl<C: SendSync> Set for SparseSet<C> {
 
 #[derive(Default)]
 pub struct SparseSets {
-    sets: HashMap<TypeId, RwLock<Box<dyn Set>>>,
+    sets: HashMap<TypeId, Box<RwLock<dyn Set>>>,
 }
 
 impl SparseSets {
     pub fn insert<C: SendSync>(&mut self, entity: Entity, component: C) {
         self.sets.insert(
             TypeId::of::<C>(),
-            RwLock::new(Box::new(SparseSet::new(entity, component))),
+            Box::new(RwLock::new(SparseSet::new(entity, component))),
         );
     }
 
@@ -159,7 +159,7 @@ impl SparseSets {
             )
         };
         Some(RwLockReadGuard::map(guard, |dynbox| unsafe {
-            let dynthing: *const dyn Set = dynbox.as_ref();
+            let dynthing: *const dyn Set = dynbox;
             &*dynthing.cast::<SparseSet<C>>()
         }))
     }
@@ -174,7 +174,7 @@ impl SparseSets {
             )
         };
         Some(RwLockWriteGuard::map(guard, |dynbox| unsafe {
-            let dynthing: *mut dyn Set = dynbox.as_mut();
+            let dynthing: *mut dyn Set = dynbox;
             &mut *dynthing.cast::<SparseSet<C>>()
         }))
     }

--- a/src/world.rs
+++ b/src/world.rs
@@ -48,7 +48,7 @@ impl World {
         self.sparse_sets.get_mut::<C>()
     }
 
-    pub(crate) fn attach_component<C: SendSync>(&mut self, entity: Entity, component: C) {
+    pub(crate) fn attach_component<C: SendSync>(&self, entity: Entity, component: C) {
         if let Some(mut set) = self.sparse_sets.get_mut::<C>() {
             set.insert(entity, component);
         } else {
@@ -67,11 +67,11 @@ impl World {
         self.sparse_sets.remove(entity);
     }
 
-    pub fn attach<C: AttachComponents>(&mut self, entity: Entity, components: C) {
+    pub fn attach<C: AttachComponents>(&self, entity: Entity, components: C) {
         components.attach_to_entity(self, entity);
     }
 
-    pub fn detach<C: 'static>(&mut self, entity: Entity) {
+    pub fn detach<C: 'static>(&self, entity: Entity) {
         if let Some(mut set) = self.sparse_sets.get_mut::<C>() {
             set.remove(entity)
         }

--- a/tests/entity.rs
+++ b/tests/entity.rs
@@ -1,0 +1,22 @@
+use secs::prelude::*;
+
+#[test]
+#[should_panic(
+    expected = "Tried to access component `u32` mutably, but it was already being written to or read from"
+)]
+fn detach_related_in_query() {
+    let mut world = World::default();
+
+    world.spawn((1_u32,));
+    world.spawn((10_u32, "foo"));
+    world.query::<(&u32,)>(|entity, (_,)| world.detach::<u32>(entity));
+}
+
+#[test]
+fn detach_unrelated_in_query() {
+    let mut world = World::default();
+
+    world.spawn((1_u32,));
+    world.spawn((10_u32, "foo"));
+    world.query::<(&u32,)>(|entity, (_,)| world.detach::<&str>(entity));
+}

--- a/ui_test_deps/Cargo.lock
+++ b/ui_test_deps/Cargo.lock
@@ -27,6 +27,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "elsa"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2343daaeabe09879d4ea058bb4f1e63da3fc07dadc6634e01bda1b3d6a9d9d2b"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +94,7 @@ name = "secs"
 version = "0.1.0"
 dependencies = [
  "bimap",
+ "elsa",
  "parking_lot",
  "thunderdome",
 ]
@@ -94,6 +104,12 @@ name = "smallvec"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "thunderdome"


### PR DESCRIPTION
same with detaching. As long as none of the current queries are over a component type, you can attach and detach that component type at will.

spawning could work the same way, but seems easy to get wrong. Despawning must iterate over all components, so it would always fail. Thus I kept the `&mut World` requirement for spawning and despawning.