### PR TITLE
Some sparse map simplifcations and cheaper iteration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,12 +79,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bimap"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,7 +740,6 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 name = "secs"
 version = "0.1.0"
 dependencies = [
- "bimap",
  "elsa",
  "macroquad",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-bimap = "0.6.3"
 elsa = "1.11.0"
 parking_lot = "0.12.3"
 rayon = { version = "1.10.0", optional = true }

--- a/src/query.rs
+++ b/src/query.rs
@@ -60,7 +60,7 @@ impl<C: 'static> SparseSetGetter for &C {
         iter.get(entity)
     }
     fn iter<'b>(iter: &'b mut Self::Iter<'_>) -> impl Iterator<Item = (Entity, Self::Short<'b>)> {
-        (&**iter).into_iter()
+        iter.iter()
     }
 }
 
@@ -93,7 +93,7 @@ impl<C: 'static> SparseSetGetter for &mut C {
         iter.get_mut(entity)
     }
     fn iter<'b>(iter: &'b mut Self::Iter<'_>) -> impl Iterator<Item = (Entity, Self::Short<'b>)> {
-        (&mut **iter).into_iter()
+        iter.iter_mut()
     }
 }
 

--- a/src/sparse_set.rs
+++ b/src/sparse_set.rs
@@ -60,65 +60,13 @@ impl<C> SparseSet<C> {
         let &id = self.sparse.get(&entity)?;
         Some(&mut self.dense[id])
     }
-}
 
-pub struct SparseSetIter<'a, C> {
-    iter: std::collections::hash_map::Iter<'a, Entity, usize>,
-    dense: &'a [C],
-}
-
-impl<'a, C> Iterator for SparseSetIter<'a, C> {
-    type Item = (Entity, &'a C);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter
-            .next()
-            .map(|(&entity, &idx)| (entity, &self.dense[idx]))
+    pub fn iter(&self) -> impl Iterator<Item = (Entity, &C)> {
+        self.ids.iter().copied().zip(self.dense.iter())
     }
-}
 
-impl<'a, C> IntoIterator for &'a SparseSet<C> {
-    type Item = (Entity, &'a C);
-
-    type IntoIter = SparseSetIter<'a, C>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        SparseSetIter {
-            iter: self.sparse.iter(),
-            dense: &self.dense,
-        }
-    }
-}
-
-pub struct SparseSetIterMut<'a, C> {
-    iter: std::collections::hash_map::Iter<'a, Entity, usize>,
-    dense: &'a mut [C],
-}
-
-impl<'a, C> Iterator for SparseSetIterMut<'a, C> {
-    type Item = (Entity, &'a mut C);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        // SAFETY: We know for a fact that no two entries in `iter` have the same `usize` value,
-        // so we are able to ensure mutual exclusion.
-        let dense: &'a mut [C] =
-            unsafe { std::slice::from_raw_parts_mut(self.dense.as_mut_ptr(), self.dense.len()) };
-        self.iter
-            .next()
-            .map(move |(&entity, &idx)| (entity, &mut dense[idx]))
-    }
-}
-
-impl<'a, C> IntoIterator for &'a mut SparseSet<C> {
-    type Item = (Entity, &'a mut C);
-
-    type IntoIter = SparseSetIterMut<'a, C>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        SparseSetIterMut {
-            iter: self.sparse.iter(),
-            dense: &mut self.dense,
-        }
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (Entity, &mut C)> {
+        self.ids.iter().copied().zip(self.dense.iter_mut())
     }
 }
 

--- a/ui_test_deps/Cargo.lock
+++ b/ui_test_deps/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "bimap"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
-
-[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,7 +87,6 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 name = "secs"
 version = "0.1.0"
 dependencies = [
- "bimap",
  "elsa",
  "parking_lot",
  "thunderdome",


### PR DESCRIPTION
Now we iterate over two vecs together instead of iterating over a hashmap and using that to randomly select elements from the dense map. This should be much more cache friendly without a loss in single-element lookup.

Basically it optimizes `BiMap<T, usize>` because the second one can just be a `Vec<T>` instead of a `HashMap<usize, T>` like `BiMap` does