### PR TITLE
Avoid a dependency for `Entity` ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,7 +744,6 @@ dependencies = [
  "macroquad",
  "parking_lot",
  "rayon",
- "thunderdome",
  "ui_test",
 ]
 
@@ -881,12 +880,6 @@ dependencies = [
  "cfg-if",
  "once_cell",
 ]
-
-[[package]]
-name = "thunderdome"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e170f93360bf9ae6fe3c31116bbf27adb1d054cedd6bc3d7857e34f2d98d0b"
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2024"
 elsa = "1.11.0"
 parking_lot = "0.12.3"
 rayon = { version = "1.10.0", optional = true }
-thunderdome = "0.6.1"
 
 [features]
 multithreaded = ["rayon"]

--- a/src/components.rs
+++ b/src/components.rs
@@ -5,12 +5,14 @@ pub trait AttachComponents {
 }
 
 impl<C1: SendSync> AttachComponents for (C1,) {
+    #[track_caller]
     fn attach_to_entity(self, world: &World, entity: Entity) {
         world.attach_component(entity, self.0);
     }
 }
 
 impl<C1: SendSync, C2: SendSync> AttachComponents for (C1, C2) {
+    #[track_caller]
     fn attach_to_entity(self, world: &World, entity: Entity) {
         world.attach_component(entity, self.0);
         world.attach_component(entity, self.1);
@@ -18,6 +20,7 @@ impl<C1: SendSync, C2: SendSync> AttachComponents for (C1, C2) {
 }
 
 impl<C1: SendSync, C2: SendSync, C3: SendSync> AttachComponents for (C1, C2, C3) {
+    #[track_caller]
     fn attach_to_entity(self, world: &World, entity: Entity) {
         world.attach_component(entity, self.0);
         world.attach_component(entity, self.1);
@@ -26,6 +29,7 @@ impl<C1: SendSync, C2: SendSync, C3: SendSync> AttachComponents for (C1, C2, C3)
 }
 
 impl<C1: SendSync, C2: SendSync, C3: SendSync, C4: SendSync> AttachComponents for (C1, C2, C3, C4) {
+    #[track_caller]
     fn attach_to_entity(self, world: &World, entity: Entity) {
         world.attach_component(entity, self.0);
         world.attach_component(entity, self.1);
@@ -37,6 +41,7 @@ impl<C1: SendSync, C2: SendSync, C3: SendSync, C4: SendSync> AttachComponents fo
 impl<C1: SendSync, C2: SendSync, C3: SendSync, C4: SendSync, C5: SendSync> AttachComponents
     for (C1, C2, C3, C4, C5)
 {
+    #[track_caller]
     fn attach_to_entity(self, world: &World, entity: Entity) {
         world.attach_component(entity, self.0);
         world.attach_component(entity, self.1);

--- a/src/sparse_set.rs
+++ b/src/sparse_set.rs
@@ -93,6 +93,7 @@ impl SparseSets {
         );
     }
 
+    #[track_caller]
     pub fn remove(&mut self, entity: Entity) {
         for set in self.sets.as_mut().values() {
             let Some(mut guard) = set.try_write() else {

--- a/src/world.rs
+++ b/src/world.rs
@@ -50,6 +50,7 @@ impl World {
         self.sparse_sets.get_mut::<C>()
     }
 
+    #[track_caller]
     pub(crate) fn attach_component<C: SendSync>(&self, entity: Entity, component: C) {
         if let Some(mut set) = self.sparse_sets.get_mut::<C>() {
             set.insert(entity, component);
@@ -58,6 +59,7 @@ impl World {
         }
     }
 
+    #[track_caller]
     pub fn spawn<C: AttachComponents>(&self, components: C) -> Entity {
         let entity = self.entities.fetch_add(1, Ordering::Relaxed);
         let entity = Entity(NonZeroU64::new(entity + 1).unwrap());
@@ -65,25 +67,30 @@ impl World {
         entity
     }
 
+    #[track_caller]
     pub fn despawn(&mut self, entity: Entity) {
         self.sparse_sets.remove(entity);
     }
 
+    #[track_caller]
     pub fn attach<C: AttachComponents>(&self, entity: Entity, components: C) {
         components.attach_to_entity(self, entity);
     }
 
+    #[track_caller]
     pub fn detach<C: 'static>(&self, entity: Entity) {
         if let Some(mut set) = self.sparse_sets.get_mut::<C>() {
             set.remove(entity)
         }
     }
 
+    #[track_caller]
     pub fn get<C: 'static>(&self, entity: Entity) -> Option<MappedRwLockReadGuard<C>> {
         let set = self.sparse_sets.get::<C>()?;
         MappedRwLockReadGuard::try_map(set, |set| set.get(entity)).ok()
     }
 
+    #[track_caller]
     pub fn get_mut<C: 'static>(&self, entity: Entity) -> Option<MappedRwLockWriteGuard<C>> {
         let set = self.sparse_sets.get_mut::<C>()?;
         MappedRwLockWriteGuard::try_map(set, |set| set.get_mut(entity)).ok()

--- a/src/world.rs
+++ b/src/world.rs
@@ -58,7 +58,7 @@ impl World {
         }
     }
 
-    pub fn spawn<C: AttachComponents>(&mut self, components: C) -> Entity {
+    pub fn spawn<C: AttachComponents>(&self, components: C) -> Entity {
         let entity = self.entities.fetch_add(1, Ordering::Relaxed);
         let entity = Entity(NonZeroU64::new(entity + 1).unwrap());
         components.attach_to_entity(self, entity);

--- a/tests/entity.rs
+++ b/tests/entity.rs
@@ -5,7 +5,7 @@ use secs::prelude::*;
     expected = "Tried to access component `u32` mutably, but it was already being written to or read from"
 )]
 fn detach_related_in_query() {
-    let mut world = World::default();
+    let world = World::default();
 
     world.spawn((1_u32,));
     world.spawn((10_u32, "foo"));
@@ -14,9 +14,34 @@ fn detach_related_in_query() {
 
 #[test]
 fn detach_unrelated_in_query() {
-    let mut world = World::default();
+    let world = World::default();
 
     world.spawn((1_u32,));
     world.spawn((10_u32, "foo"));
     world.query::<(&u32,)>(|entity, (_,)| world.detach::<&str>(entity));
+}
+
+#[test]
+#[should_panic(
+    expected = "Tried to access component `u32` mutably, but it was already being written to or read from"
+)]
+fn spawn_related_in_query() {
+    let world = World::default();
+
+    world.spawn((1_u32,));
+    world.spawn((10_u32, "foo"));
+    world.query::<(&u32,)>(|_, (&i,)| {
+        world.spawn((i * 2,));
+    });
+}
+
+#[test]
+fn spawn_unrelated_in_query() {
+    let world = World::default();
+
+    world.spawn((1_u32,));
+    world.spawn((10_u32, "foo"));
+    world.query::<(&u32,)>(|_, (_,)| {
+        world.spawn(("bar",));
+    });
 }

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -5,7 +5,7 @@ use secs::prelude::*;
     expected = "Tried to access component `u32` mutably, but it was already being written to or read from"
 )]
 fn aliasing_mutation() {
-    let mut world = World::default();
+    let world = World::default();
 
     world.spawn((1_u32,));
     world.spawn((10_u32,));
@@ -20,7 +20,7 @@ fn aliasing_mutation() {
 
 #[test]
 fn optional_components() {
-    let mut world = World::default();
+    let world = World::default();
 
     world.spawn((1_u32,));
     world.spawn((10_u32, "foo"));

--- a/tests/ui/double_mut_borrow_panic.rs
+++ b/tests/ui/double_mut_borrow_panic.rs
@@ -3,7 +3,7 @@
 use secs::prelude::*;
 
 fn main() {
-    let mut world = World::default();
+    let world = World::default();
 
     world.spawn((1_u32,));
     world.spawn((10_u32,));

--- a/tests/ui/empty_tuple.rs
+++ b/tests/ui/empty_tuple.rs
@@ -1,7 +1,7 @@
 use secs::prelude::*;
 
 fn optional_components() {
-    let mut world = World::default();
+    let world = World::default();
 
     world.query::<()>(|_, ()| {});
     //~^ ERROR: `()` is not a valid query

--- a/tests/ui/missing_ref.rs
+++ b/tests/ui/missing_ref.rs
@@ -1,7 +1,7 @@
 use secs::prelude::*;
 
 fn optional_components() {
-    let mut world = World::default();
+    let world = World::default();
 
     let mut results = vec![];
     world.query::<(&u32, &str)>(|_, _| {});

--- a/tests/ui/non_tuple_query.rs
+++ b/tests/ui/non_tuple_query.rs
@@ -1,7 +1,7 @@
 use secs::prelude::*;
 
 fn optional_components() {
-    let mut world = World::default();
+    let world = World::default();
 
     world.query::<u32>(|_, _| {});
     //~^ ERROR: `u32` is not a valid query

--- a/tests/ui/opt_as_first.rs
+++ b/tests/ui/opt_as_first.rs
@@ -1,7 +1,7 @@
 use secs::prelude::*;
 
 fn optional_components() {
-    let mut world = World::default();
+    let world = World::default();
 
     world.spawn((1_u32,));
     world.spawn((10_u32, "foo"));

--- a/tests/ui/too_many_tuple_elements.rs
+++ b/tests/ui/too_many_tuple_elements.rs
@@ -1,7 +1,7 @@
 use secs::prelude::*;
 
 fn optional_components() {
-    let mut world = World::default();
+    let world = World::default();
 
     world.query::<(u32, i32, u8, i8, u64, i64, u16, i16, u128, i128)>(|_, ()| {});
     //~^ ERROR: `(u32, i32, u8, i8, u64, i64, u16, i16, u128, i128)` is not a valid query

--- a/ui_test_deps/Cargo.lock
+++ b/ui_test_deps/Cargo.lock
@@ -89,7 +89,6 @@ version = "0.1.0"
 dependencies = [
  "elsa",
  "parking_lot",
- "thunderdome",
 ]
 
 [[package]]
@@ -103,12 +102,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "thunderdome"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e170f93360bf9ae6fe3c31116bbf27adb1d054cedd6bc3d7857e34f2d98d0b"
 
 [[package]]
 name = "ui_test_deps"


### PR DESCRIPTION
We weren't really using any of the thunderdome capabilities that make it useful. So I simplified the id generation to a simple `u64`. We should never run out of ids, even multithreaded id generation should be fine unless two threads spend most of their work in generating ids