### PR TITLE
Simplify parallel vs serial system registration

### DIFF
--- a/examples/macroquad.rs
+++ b/examples/macroquad.rs
@@ -1,5 +1,5 @@
 use macroquad::{prelude::*, rand, ui::root_ui};
-use secs::prelude::{ExecutionMode, World};
+use secs::prelude::World;
 
 struct GameState {
     paused: bool,
@@ -146,16 +146,16 @@ async fn main() {
     world.add_resource(GameState { paused: false });
 
     // macroquad is single threaded so any systems executing its code cannot be run in parallel
-    world.add_system(move_system, ExecutionMode::Serial);
+    world.add_system(move_system);
     #[cfg(feature = "multithreaded")]
     {
-        world.add_system(collision_system, ExecutionMode::Parallel);
+        world.add_parallel_system(collision_system);
     }
     #[cfg(not(feature = "multithreaded"))]
     {
-        world.add_system(collision_system, ExecutionMode::Serial);
+        world.add_system(collision_system);
     }
-    world.add_system(render_system, ExecutionMode::Serial);
+    world.add_system(render_system);
 
     loop {
         clear_background(SKYBLUE);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,5 @@ mod sparse_set;
 mod world;
 
 pub mod prelude {
-    pub use super::scheduler::ExecutionMode;
     pub use super::world::{Entity, World};
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -9,7 +9,7 @@ use thunderdome::{Arena, Index};
 use crate::{
     components::AttachComponents,
     query::Query,
-    scheduler::{ExecutionMode, MutSystem, Scheduler, System},
+    scheduler::{MutSystem, Scheduler, System},
     sparse_set::{SparseSet, SparseSets},
 };
 
@@ -115,8 +115,13 @@ impl World {
         self.resources.remove(&TypeId::of::<R>());
     }
 
-    pub fn add_system(&mut self, system: System, mode: ExecutionMode) {
-        self.scheduler.register(system, mode);
+    #[cfg(feature = "multithreaded")]
+    pub fn add_parallel_system(&mut self, system: System) {
+        self.scheduler.register_parallel(system);
+    }
+
+    pub fn add_system(&mut self, system: System) {
+        self.scheduler.register(system);
     }
 
     pub fn add_mut_system(&mut self, system: MutSystem) {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -12,7 +12,7 @@ fn remove() {
     // While this is bogus in many cases, it's the only way to catch the rare cases where
     // it's an issue. So we do this provenance preserving deduplication by eagerly creating a pointer.
     let boom = boom as fn(&World);
-    world.add_system(boom, ExecutionMode::Serial);
+    world.add_system(boom);
     assert!(std::panic::catch_unwind(AssertUnwindSafe(|| world.run_systems())).is_err());
     world.remove_system(boom);
     world.run_systems();
@@ -37,7 +37,7 @@ fn remove_within() {
     }
 
     world.add_mut_system(defuse);
-    world.add_system(boom, ExecutionMode::Serial);
+    world.add_system(boom);
     world.run_systems();
 }
 


### PR DESCRIPTION
Unsure if you ever want a runtime decision deciding whether to make a system parallel or not. But it seems like it could be easily done in user code for the rare cases that need that.