### PR TITLE
Expose the `SysId` type so it can be used to store the ids

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,5 @@ mod scheduler;
 mod sparse_set;
 mod world;
 
+pub use scheduler::SysId;
 pub use world::{Entity, World};

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -16,6 +16,9 @@ impl<T: Fn(&World) + SendSync> SystemFn for T {}
 
 pub type System = (u64, Arc<dyn SystemFn>);
 
+/// A unique ID for a specific system generated when
+/// the system was [registered](System::register).
+/// Can be used to [deregister](Scheduler::deregister) the system later.
 #[derive(Copy, Clone)]
 pub struct SysId(u64);
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use secs::World;
+use secs::{SysId, World};
 
 #[test]
 fn remove() {
@@ -11,7 +11,7 @@ fn remove() {
     fn boom(_: &World) {
         panic!()
     }
-    let id = world.add_system(boom);
+    let id: SysId = world.add_system(boom);
     assert!(std::panic::catch_unwind(AssertUnwindSafe(|| world.run_systems())).is_err());
     world.remove_system(id);
     world.run_systems();


### PR DESCRIPTION
wanted to use this in my game and realized I can't store them or return them from functions