### PR TITLE
Track dead entities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ rayon = { version = "1.10.0", optional = true }
 
 [features]
 multithreaded = ["rayon"]
+track_dead_entities = []
 
 [dev-dependencies]
 macroquad = "0.4.13"

--- a/tests/entity.rs
+++ b/tests/entity.rs
@@ -53,6 +53,7 @@ fn spawn_related_in_query() {
 
 #[test]
 #[should_panic(expected = "Attaching `alloc::string::String` to despawned entity")]
+#[cfg(any(debug_assertions, feature = "track_dead_entities"))]
 fn attach_to_despawned() {
     let mut world = World::default();
 

--- a/tests/ui/panic_location.rs
+++ b/tests/ui/panic_location.rs
@@ -1,0 +1,13 @@
+//@ run: 101
+
+use secs::World;
+
+fn main() {
+    let mut world = World::default();
+
+    let id = world.spawn((1_u32,));
+    world.spawn((10_u32, "foo"));
+    world.despawn(id);
+
+    world.get::<u32>(id);
+}

--- a/tests/ui/panic_location.run.stderr
+++ b/tests/ui/panic_location.run.stderr
@@ -1,4 +1,4 @@
 
 thread 'main' panicked at tests/ui/panic_location.rs:12:11:
-Getting `u32` from despawned entity
+Getting `u32` from despawned entity (despawned at tests/ui/panic_location.rs:10:11)
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/panic_location.run.stderr
+++ b/tests/ui/panic_location.run.stderr
@@ -1,0 +1,4 @@
+
+thread 'main' panicked at tests/ui/panic_location.rs:12:11:
+Getting `u32` from despawned entity
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
No backtrace, but at least the location of where it was despawned.

I also made it only track this in debug mode or when the cargo feature is enabled. This way you can turn it on even if all deps are built in release mode, but turn it off when you ship a game. Otherwise you're gonna run out of memory at some point. Very slowly, as it's just a few bytes per entity, but if you have a long running server that would be noticeable.