### PR TITLE
Allow systems to have mutable state not shared with others

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -15,9 +15,9 @@ use crate::world::World;
 #[derive(Copy, Clone)]
 pub struct SysId(u64);
 
-pub trait SystemFn: Fn(&World) + SendSync {}
+pub trait SystemFn: FnMut(&World) + SendSync {}
 
-impl<T: Fn(&World) + SendSync> SystemFn for T {}
+impl<T: FnMut(&World) + SendSync> SystemFn for T {}
 
 pub type System = (SysId, Option<Box<dyn SystemFn>>);
 
@@ -92,7 +92,7 @@ impl Scheduler {
             let Some((_, sys)) = guard.get_mut(i) else {
                 break;
             };
-            let sys = sys.take().unwrap();
+            let mut sys = sys.take().unwrap();
             drop(guard);
             sys(world);
             let mut guard = self.systems.write();

--- a/src/world.rs
+++ b/src/world.rs
@@ -11,6 +11,8 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
+#[cfg(feature = "multithreaded")]
+use crate::scheduler::ParallelSystemFn;
 use crate::{
     components::AttachComponents,
     query::Query,
@@ -238,7 +240,7 @@ impl World {
     /// Add a system that will run in parallel on threads with all
     /// other parallel systems.
     #[cfg(feature = "multithreaded")]
-    pub fn add_parallel_system(&self, system: impl SystemFn) {
+    pub fn add_parallel_system(&self, system: impl ParallelSystemFn) {
         self.scheduler.register_parallel(system);
     }
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -84,6 +84,13 @@ fn query_system() {
         *i *= 2;
     });
 
+    let mut state = 5_u32;
+
+    world.add_system(move |_world| {
+        state += 1;
+        assert!(state <= 8);
+    });
+
     for _ in 0..3 {
         world.run_systems();
     }


### PR DESCRIPTION
This avoids having to use `RefCell` or `RwLock` if a system is the only system ever accessing some data.