### PR TITLE
Remove multithreading support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,15 @@ jobs:
     - name: Miri
       run: env MIRIFLAGS="-Zmiri-tree-borrows" cargo miri test
 
+  docs:
+    name: test docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - name: Doc
+      run: cargo test --doc
+
   tests:
     strategy:
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,12 +79,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitflags"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
-
-[[package]]
 name = "bstr"
 version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,35 +235,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "either"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elsa"
@@ -427,16 +396,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,29 +528,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,7 +539,7 @@ version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -648,35 +584,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
-dependencies = [
- "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -738,19 +645,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "secs"
 version = "0.1.0"
 dependencies = [
  "elsa",
  "macroquad",
- "parking_lot",
- "rayon",
  "ui_test",
 ]
 
@@ -815,12 +714,6 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "smallvec"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "spanned"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,8 @@ edition = "2024"
 
 [dependencies]
 elsa = "1.11.0"
-parking_lot = "0.12.3"
-rayon = { version = "1.10.0", optional = true }
 
 [features]
-multithreaded = ["rayon"]
 track_dead_entities = []
 
 [dev-dependencies]

--- a/examples/macroquad.rs
+++ b/examples/macroquad.rs
@@ -47,7 +47,7 @@ fn move_system(game_state: Arc<GameState>) -> impl Fn(&World) {
             return;
         }
 
-        world.query::<(&mut Position, &mut Velocity)>(|_entity, (pos, vel)| {
+        world.query(|_entity, pos: &mut Position, vel: &mut Velocity| {
             vel.x = 0.;
             vel.y = 0.;
 
@@ -71,9 +71,9 @@ fn move_system(game_state: Arc<GameState>) -> impl Fn(&World) {
 }
 
 fn collision_system(world: &World) {
-    world.query::<(&Position, &mut Sprite, &mut Score)>(
-        |_, (player_center, player, player_score)| {
-            world.query::<(&Position, &mut Powerup)>(|_, (powerup_center, powerup)| {
+    world.query(
+        |_, player_center: &Position, player: &mut Sprite, player_score: &mut Score| {
+            world.query(|_, powerup_center: &Position, powerup: &mut Powerup| {
                 if powerup.active
                     && (powerup_center.x - player_center.x).abs()
                         < (powerup.width * 0.5) + (player.width * 0.5)
@@ -109,7 +109,7 @@ fn render_system(game_state: Arc<GameState>) -> impl Fn(&World) {
             return;
         }
 
-        world.query::<(&Position, &Sprite)>(|_, (pos, sprite)| match sprite.shape {
+        world.query(|_, pos: &Position, sprite: &Sprite| match sprite.shape {
             Shape::Square => draw_rectangle(
                 pos.x - (sprite.width * 0.5),
                 pos.y - (sprite.width * 0.5),
@@ -120,7 +120,7 @@ fn render_system(game_state: Arc<GameState>) -> impl Fn(&World) {
             Shape::Circle => draw_circle(pos.x, pos.y, sprite.width * 0.5, PURPLE),
         });
 
-        world.query::<(&Powerup, &Position)>(|_, (powerup, pos)| {
+        world.query(|_, powerup: &Powerup, pos: &Position| {
             if powerup.active {
                 draw_rectangle(
                     pos.x - (powerup.width * 0.5),
@@ -132,7 +132,7 @@ fn render_system(game_state: Arc<GameState>) -> impl Fn(&World) {
             }
         });
 
-        world.query::<(&Score,)>(|_, (score,)| {
+        world.query(|_, score: &Score| {
             root_ui().label(None, &format!("Player Score: {}", score.value));
         });
     }

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,17 +1,19 @@
-use crate::world::{Entity, SendSync, World};
+use crate::world::{Entity, World};
+
+use std::any::Any;
 
 pub trait AttachComponents {
     fn attach_to_entity(self, world: &World, entity: Entity);
 }
 
-impl<C1: SendSync> AttachComponents for (C1,) {
+impl<C1: Any> AttachComponents for (C1,) {
     #[track_caller]
     fn attach_to_entity(self, world: &World, entity: Entity) {
         world.attach_component(entity, self.0);
     }
 }
 
-impl<C1: SendSync, C2: SendSync> AttachComponents for (C1, C2) {
+impl<C1: Any, C2: Any> AttachComponents for (C1, C2) {
     #[track_caller]
     fn attach_to_entity(self, world: &World, entity: Entity) {
         world.attach_component(entity, self.0);
@@ -19,7 +21,7 @@ impl<C1: SendSync, C2: SendSync> AttachComponents for (C1, C2) {
     }
 }
 
-impl<C1: SendSync, C2: SendSync, C3: SendSync> AttachComponents for (C1, C2, C3) {
+impl<C1: Any, C2: Any, C3: Any> AttachComponents for (C1, C2, C3) {
     #[track_caller]
     fn attach_to_entity(self, world: &World, entity: Entity) {
         world.attach_component(entity, self.0);
@@ -28,7 +30,7 @@ impl<C1: SendSync, C2: SendSync, C3: SendSync> AttachComponents for (C1, C2, C3)
     }
 }
 
-impl<C1: SendSync, C2: SendSync, C3: SendSync, C4: SendSync> AttachComponents for (C1, C2, C3, C4) {
+impl<C1: Any, C2: Any, C3: Any, C4: Any> AttachComponents for (C1, C2, C3, C4) {
     #[track_caller]
     fn attach_to_entity(self, world: &World, entity: Entity) {
         world.attach_component(entity, self.0);
@@ -38,9 +40,7 @@ impl<C1: SendSync, C2: SendSync, C3: SendSync, C4: SendSync> AttachComponents fo
     }
 }
 
-impl<C1: SendSync, C2: SendSync, C3: SendSync, C4: SendSync, C5: SendSync> AttachComponents
-    for (C1, C2, C3, C4, C5)
-{
+impl<C1: Any, C2: Any, C3: Any, C4: Any, C5: Any> AttachComponents for (C1, C2, C3, C4, C5) {
     #[track_caller]
     fn attach_to_entity(self, world: &World, entity: Entity) {
         world.attach_component(entity, self.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,6 @@
 //! Start by creating a [World] and invoke methods on it
 //! to fill your world with life.
 
-#[cfg(not(feature = "multithreaded"))]
-use elsa::FrozenVec;
-#[cfg(feature = "multithreaded")]
-use elsa::sync::FrozenVec;
-
 mod components;
 mod query;
 mod scheduler;

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,4 +1,4 @@
-use parking_lot::{MappedRwLockReadGuard, MappedRwLockWriteGuard};
+use std::cell::{Ref, RefMut};
 
 use crate::{
     sparse_set::SparseSet,
@@ -46,7 +46,7 @@ pub trait SparseSetGetter {
 
 impl<C: 'static> SparseSetGetter for &C {
     type Short<'b> = &'b C;
-    type Iter<'c> = MappedRwLockReadGuard<'c, SparseSet<C>>;
+    type Iter<'c> = Ref<'c, SparseSet<C>>;
     #[track_caller]
     fn get_set(world: &World) -> Option<Self::Iter<'_>> {
         world.sparse_sets.get()
@@ -79,7 +79,7 @@ impl<T: SparseSetGetter> SparseSetGetter for Option<T> {
 
 impl<C: 'static> SparseSetGetter for &mut C {
     type Short<'b> = &'b mut C;
-    type Iter<'c> = MappedRwLockWriteGuard<'c, SparseSet<C>>;
+    type Iter<'c> = RefMut<'c, SparseSet<C>>;
     #[track_caller]
     fn get_set(world: &World) -> Option<Self::Iter<'_>> {
         world.sparse_sets.get_mut()

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,13 +1,5 @@
-#[cfg(feature = "multithreaded")]
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
-
-use crate::world::SendSync;
-use parking_lot::RwLock;
-#[cfg(feature = "multithreaded")]
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
-
 use crate::world::World;
+use std::cell::{Cell, RefCell};
 
 /// A unique ID for a specific system generated when
 /// the system was [registered](Scheduler::register).
@@ -15,87 +7,48 @@ use crate::world::World;
 #[derive(Copy, Clone)]
 pub struct SysId(u64);
 
-pub trait SystemFn: FnMut(&World) + SendSync {}
+pub trait SystemFn: FnMut(&World) + 'static {}
 
-impl<T: FnMut(&World) + SendSync> SystemFn for T {}
+impl<T: FnMut(&World) + 'static> SystemFn for T {}
 
 pub type System = (SysId, Option<Box<dyn SystemFn>>);
 
-#[cfg(feature = "multithreaded")]
-pub trait ParallelSystemFn: Fn(&World) + SendSync {}
-
-#[cfg(feature = "multithreaded")]
-impl<T: Fn(&World) + SendSync> ParallelSystemFn for T {}
-
-#[cfg(feature = "multithreaded")]
-pub type ParallelSystem = (SysId, Arc<dyn ParallelSystemFn>);
-
 #[derive(Default)]
 pub struct Scheduler {
-    next_id: AtomicU64,
-    #[cfg(feature = "multithreaded")]
-    parallel_systems: RwLock<Vec<ParallelSystem>>,
-    systems: RwLock<Vec<System>>,
+    next_id: Cell<u64>,
+    systems: RefCell<Vec<System>>,
 }
 
 impl Scheduler {
-    #[cfg(feature = "multithreaded")]
-    pub fn register_parallel(&self, system: impl ParallelSystemFn) -> SysId {
-        let id = SysId(self.next_id.fetch_add(1, Ordering::Relaxed));
-        self.parallel_systems.write().push((id, Arc::new(system)));
-        id
-    }
-
     pub fn register(&self, system: impl SystemFn) -> SysId {
-        let id = SysId(self.next_id.fetch_add(1, Ordering::Relaxed));
-        self.systems.write().push((id, Some(Box::new(system))));
+        let id = SysId(self.next_id.get());
+        self.next_id.set(id.0 + 1);
+        self.systems.borrow_mut().push((id, Some(Box::new(system))));
         id
     }
 
     pub fn deregister(&self, system: SysId) {
         let position = self
             .systems
-            .read()
+            .borrow()
             .iter()
             .position(|(id, _)| id.0 == system.0);
         if let Some(pos) = position {
-            let _ = self.systems.write().remove(pos);
-            #[cfg(feature = "multithreaded")]
-            return;
-        }
-        #[cfg(feature = "multithreaded")]
-        let position = self
-            .parallel_systems
-            .read()
-            .iter()
-            .position(|(id, _)| id.0 == system.0);
-        #[cfg(feature = "multithreaded")]
-        if let Some(pos) = position {
-            let _ = self.parallel_systems.write().remove(pos);
+            let _ = self.systems.borrow_mut().remove(pos);
         }
     }
 
     pub fn run(&self, world: &World) {
-        #[cfg(feature = "multithreaded")]
-        let len = self.parallel_systems.read().len();
-        #[cfg(feature = "multithreaded")]
-        let systems = &self.parallel_systems;
-        #[cfg(feature = "multithreaded")]
-        (0..len)
-            .into_par_iter()
-            .filter_map(|i| Some(systems.read().get(i)?.1.clone()))
-            .for_each(|sys| sys(world));
-
-        let len = self.systems.read().len();
+        let len = self.systems.borrow().len();
         for i in 0..len {
-            let mut guard = self.systems.write();
+            let mut guard = self.systems.borrow_mut();
             let Some((_, sys)) = guard.get_mut(i) else {
                 break;
             };
             let mut sys = sys.take().unwrap();
             drop(guard);
             sys(world);
-            let mut guard = self.systems.write();
+            let mut guard = self.systems.borrow_mut();
             let Some((_, entry)) = guard.get_mut(i) else {
                 break;
             };

--- a/src/world.rs
+++ b/src/world.rs
@@ -206,15 +206,12 @@ impl World {
     /// ```rust
     /// # use secs::World;
     /// # let world = World::default();
-    /// world.query::<(&String, &u32)>(|entity_id, (s, u)| {
+    /// world.query(|entity_id, s: &String, u: &u32| {
     ///     println!("{s}: {u}");
     /// });
     /// ```
     #[track_caller]
-    pub fn query<Q: Query>(
-        &self,
-        f: impl for<'b, 'c, 'd, 'e, 'f> FnMut(Entity, Q::Short<'b, 'c, 'd, 'e, 'f>),
-    ) {
+    pub fn query<Q: Query<T>, T>(&self, f: Q) {
         Q::get_components(self, f)
     }
 
@@ -247,15 +244,6 @@ impl World {
     /// Add a system that will run after all systems that were added before it.
     pub fn add_system(&self, system: impl SystemFn) -> SysId {
         self.scheduler.register(system)
-    }
-
-    /// Add a system that will run after all systems that were added before it.
-    pub fn add_query_system<Q: Query>(
-        &self,
-        system: impl for<'b, 'c, 'd, 'e, 'f> Fn(&World, Entity, Q::Short<'b, 'c, 'd, 'e, 'f>) + SendSync,
-    ) -> SysId {
-        self.scheduler
-            .register(move |world| world.query::<Q>(|e, q| system(world, e, q)))
     }
 
     /// Remove a system. Note that due to how compilers work this may not

--- a/tests/entity.rs
+++ b/tests/entity.rs
@@ -21,7 +21,7 @@ fn detach_related_in_query() {
 
     world.spawn((1_u32,));
     world.spawn((10_u32, "foo"));
-    world.query::<(&u32,)>(|entity, (_,)| {
+    world.query(|entity, _: &u32| {
         world.detach::<u32>(entity);
     });
 }
@@ -32,7 +32,7 @@ fn detach_unrelated_in_query() {
 
     world.spawn((1_u32,));
     world.spawn((10_u32, "foo"));
-    world.query::<(&u32,)>(|entity, (_,)| {
+    world.query(|entity, _: &u32| {
         world.detach::<&str>(entity);
     });
 }
@@ -46,7 +46,7 @@ fn spawn_related_in_query() {
 
     world.spawn((1_u32,));
     world.spawn((10_u32, "foo"));
-    world.query::<(&u32,)>(|_, (&i,)| {
+    world.query(|_, &i: &u32| {
         world.spawn((i * 2,));
     });
 }
@@ -68,7 +68,7 @@ fn spawn_unrelated_in_query() {
 
     world.spawn((1_u32,));
     world.spawn((10_u32, "foo"));
-    world.query::<(&u32,)>(|_, (_,)| {
+    world.query(|_, _: &u32| {
         world.spawn(("bar",));
     });
 }

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -11,7 +11,7 @@ fn aliasing_mutation() {
     world.spawn((10_u32,));
 
     // 💥 in miri with stacked borrows
-    world.query::<(&mut u32, &mut u32)>(|_, (a, b)| {
+    world.query(|_, a: &mut u32, b: &mut u32| {
         // bad bad bad
         *a = *b;
         *b = *a; // 💥 in miri with tree borrows
@@ -25,12 +25,12 @@ fn optional_components() {
     world.spawn((1_u32,));
     world.spawn((10_u32, "foo"));
     let mut results = vec![];
-    world.query::<(&u32, Option<&&str>)>(|_, (i, s)| results.push((*i, s.map(|s| *s))));
+    world.query(|_, i: &u32, s: Option<&&'static str>| results.push((*i, s.map(|s| *s))));
     results.sort();
     assert_eq!(&results[..], &[(1, None), (10, Some("foo"))]);
 
     let mut results = vec![];
-    world.query::<(&&str, &u32)>(|_, (s, i)| results.push((*i, *s)));
+    world.query(|_, s: &&'static str, i: &u32| results.push((*i, *s)));
     results.sort();
     assert_eq!(&results[..], &[(10, "foo")]);
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -1,7 +1,4 @@
-use std::{
-    panic::AssertUnwindSafe,
-    sync::{Arc, Mutex},
-};
+use std::{cell::Cell, panic::AssertUnwindSafe, rc::Rc};
 
 use secs::{SysId, World};
 
@@ -23,13 +20,13 @@ fn remove_within() {
     fn boom(_: &World) {
         panic!()
     }
-    let id = Arc::new(Mutex::new(None));
+    let id = Rc::new(Cell::new(None));
     let id2 = id.clone();
     world.add_system(move |world| {
-        world.remove_system(id.lock().unwrap().unwrap());
+        world.remove_system(id.get().unwrap());
     });
 
-    *id2.lock().unwrap() = Some(world.add_system(boom));
+    id2.set(Some(world.add_system(boom)));
     world.run_systems();
 }
 

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -42,7 +42,7 @@ fn despawn() {
     world.despawn(id);
 
     let mut results = vec![];
-    world.query::<(&u32, Option<&&str>)>(|_, (i, s)| results.push((*i, s.map(|s| *s))));
+    world.query(|_, i: &u32, s: Option<&&'static str>| results.push((*i, s.map(|s| *s))));
     assert_eq!(&results[..], &[(10, Some("foo"))]);
 }
 
@@ -55,7 +55,7 @@ fn get() {
     world.despawn(id);
 
     let mut results = vec![];
-    world.query::<(&u32,)>(|entity, (i,)| results.push((*i, world.get(entity).map(|s| *s))));
+    world.query(|entity, i: &u32| results.push((*i, world.get(entity).map(|s| *s))));
     assert_eq!(&results[..], &[(10, Some("foo"))]);
 }
 
@@ -69,20 +69,13 @@ fn get_fail() {
     world.despawn(id);
 
     let mut results = vec![];
-    world.query::<(&mut u32,)>(|entity, (i,)| results.push((*i, world.get(entity).map(|s| *s))));
+    world.query(|entity, i: &mut u32| results.push((*i, world.get(entity).map(|s| *s))));
     assert_eq!(&results[..], &[(10, Some(0_u32))]);
 }
 
 #[test]
-fn query_system() {
+fn mut_system() {
     let world = World::default();
-
-    let id = world.spawn((1_u32,));
-    world.spawn((10_u32, "foo"));
-
-    world.add_query_system::<(&mut u32,)>(|_world, _entity, (i,)| {
-        *i *= 2;
-    });
 
     let mut state = 5_u32;
 
@@ -94,6 +87,4 @@ fn query_system() {
     for _ in 0..3 {
         world.run_systems();
     }
-    let i = world.get::<u32>(id).unwrap();
-    assert_eq!(*i, 8);
 }

--- a/tests/ui/double_mut_borrow_panic.rs
+++ b/tests/ui/double_mut_borrow_panic.rs
@@ -8,5 +8,5 @@ fn main() {
     world.spawn((1_u32,));
     world.spawn((10_u32,));
 
-    world.query::<(&mut u32, &mut u32)>(|_, (_, _)| {});
+    world.query(|_, _: &mut u32, _: &mut u32| {});
 }

--- a/tests/ui/empty_tuple.rs
+++ b/tests/ui/empty_tuple.rs
@@ -3,6 +3,6 @@ use secs::World;
 fn optional_components() {
     let world = World::default();
 
-    world.query::<()>(|_, ()| {});
-    //~^ ERROR: `()` is not a valid query
+    world.query(|_, ()| {});
+    //~^ ERROR: is not a valid query
 }

--- a/tests/ui/empty_tuple.stderr
+++ b/tests/ui/empty_tuple.stderr
@@ -1,17 +1,18 @@
-error[E0277]: `()` is not a valid query
- --> tests/ui/empty_tuple.rs:6:11
-  |
-L |     world.query::<()>(|_, ()| {});
-  |           ^^^^^
-  |
-  = help: the trait `secs::query::Query` is not implemented for `()`
-  = note: only tuples with 1 or up to 5 elements can be used as queries
-  = help: the following other types implement trait `secs::query::Query`:
-            (T, U)
-            (T, U, V)
-            (T, U, V, W)
-            (T, U, V, W, X)
-            (T,)
+error[E0277]: `{closure@tests/ui/empty_tuple.rs:6:17: 6:24}` is not a valid query
+   --> tests/ui/empty_tuple.rs:6:17
+    |
+6   |     world.query(|_, ()| {});
+    |           ----- ^^^^^^^^^^
+    |           |
+    |           required by a bound introduced by this call
+    |
+    = help: the trait `secs::query::Query<_>` is not implemented for closure `{closure@tests/ui/empty_tuple.rs:6:17: 6:24}`
+    = note: only tuples with 1 or up to 5 elements can be used as queries
+note: required by a bound in `World::query`
+   --> $DIR/src/world.rs
+    |
+LLL |     pub fn query<Q: Query<T>, T>(&self, f: Q) {
+    |                     ^^^^^^^^ required by this bound in `World::query`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/missing_ref.rs
+++ b/tests/ui/missing_ref.rs
@@ -4,10 +4,9 @@ fn optional_components() {
     let world = World::default();
 
     let mut results = vec![];
-    world.query::<(&u32, &str)>(|_, _| {});
-    //~^ ERROR: the size for values of type `str` cannot be known at compilation time
+    world.query(|_, _: &u32, _: &str| {});
+    //~^ ERROR: is not a valid query
 
-    world.query::<(u32, &&str)>(|_, _| {});
-    //~^ ERROR: `u32` cannot be used as a query component
-    //~| ERROR: `u32` cannot be the first element of a query
+    world.query(|_, _: u32, _: &&str| {});
+    //~^ ERROR: is not a valid query
 }

--- a/tests/ui/missing_ref.stderr
+++ b/tests/ui/missing_ref.stderr
@@ -1,43 +1,35 @@
-error[E0277]: the size for values of type `str` cannot be known at compilation time
- --> tests/ui/missing_ref.rs:7:11
-  |
-L |     world.query::<(&u32, &str)>(|_, _| {});
-  |           ^^^^^ doesn't have a size known at compile-time
-  |
-  = help: the trait `Sized` is not implemented for `str`
-  = help: the following other types implement trait `secs::query::SparseSetGetter`:
-            &C
-            &mut C
-            Option<T>
-  = note: required for `&str` to implement `secs::query::SparseSetGetter`
+error[E0277]: `{closure@tests/ui/missing_ref.rs:7:17: 7:38}` is not a valid query
+   --> tests/ui/missing_ref.rs:7:17
+    |
+7   |     world.query(|_, _: &u32, _: &str| {});
+    |           ----- ^^^^^^^^^^^^^^^^^^^^^^^^
+    |           |
+    |           required by a bound introduced by this call
+    |
+    = help: the trait `secs::query::Query<_>` is not implemented for closure `{closure@tests/ui/missing_ref.rs:7:17: 7:38}`
+    = note: only tuples with 1 or up to 5 elements can be used as queries
+note: required by a bound in `World::query`
+   --> $DIR/src/world.rs
+    |
+LLL |     pub fn query<Q: Query<T>, T>(&self, f: Q) {
+    |                     ^^^^^^^^ required by this bound in `World::query`
 
-error[E0277]: `u32` cannot be used as a query component
-  --> tests/ui/missing_ref.rs:10:11
-   |
-LL |     world.query::<(u32, &&str)>(|_, _| {});
-   |           ^^^^^
-   |
-   = help: the trait `secs::query::SparseSetGetter` is not implemented for `u32`
-   = note: only references and `Option`s of references can be components
-   = help: the following other types implement trait `secs::query::SparseSetGetter`:
-             &C
-             &mut C
-             Option<T>
-   = note: required for `(u32, &&str)` to implement `secs::query::Query`
+error[E0277]: `{closure@tests/ui/missing_ref.rs:10:17: 10:38}` is not a valid query
+   --> tests/ui/missing_ref.rs:10:17
+    |
+10  |     world.query(|_, _: u32, _: &&str| {});
+    |           ----- ^^^^^^^^^^^^^^^^^^^^^^^^
+    |           |
+    |           required by a bound introduced by this call
+    |
+    = help: the trait `secs::query::Query<_>` is not implemented for closure `{closure@tests/ui/missing_ref.rs:10:17: 10:38}`
+    = note: only tuples with 1 or up to 5 elements can be used as queries
+note: required by a bound in `World::query`
+   --> $DIR/src/world.rs
+    |
+LLL |     pub fn query<Q: Query<T>, T>(&self, f: Q) {
+    |                     ^^^^^^^^ required by this bound in `World::query`
 
-error[E0277]: `u32` cannot be the first element of a query
-  --> tests/ui/missing_ref.rs:10:11
-   |
-LL |     world.query::<(u32, &&str)>(|_, _| {});
-   |           ^^^^^
-   |
-   = help: the trait `secs::query::Always` is not implemented for `u32`
-   = note: move another element to the front of the list
-   = help: the following other types implement trait `secs::query::Always`:
-             &T
-             &mut T
-   = note: required for `(u32, &&str)` to implement `secs::query::Query`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/non_tuple_query.rs
+++ b/tests/ui/non_tuple_query.rs
@@ -3,6 +3,6 @@ use secs::World;
 fn optional_components() {
     let world = World::default();
 
-    world.query::<u32>(|_, _| {});
+    world.query(42_u32);
     //~^ ERROR: `u32` is not a valid query
 }

--- a/tests/ui/non_tuple_query.stderr
+++ b/tests/ui/non_tuple_query.stderr
@@ -1,17 +1,18 @@
 error[E0277]: `u32` is not a valid query
- --> tests/ui/non_tuple_query.rs:6:11
-  |
-L |     world.query::<u32>(|_, _| {});
-  |           ^^^^^
-  |
-  = help: the trait `secs::query::Query` is not implemented for `u32`
-  = note: only tuples with 1 or up to 5 elements can be used as queries
-  = help: the following other types implement trait `secs::query::Query`:
-            (T, U)
-            (T, U, V)
-            (T, U, V, W)
-            (T, U, V, W, X)
-            (T,)
+   --> tests/ui/non_tuple_query.rs:6:17
+    |
+6   |     world.query(42_u32);
+    |           ----- ^^^^^^
+    |           |
+    |           required by a bound introduced by this call
+    |
+    = help: the trait `secs::query::Query<_>` is not implemented for `u32`
+    = note: only tuples with 1 or up to 5 elements can be used as queries
+note: required by a bound in `World::query`
+   --> $DIR/src/world.rs
+    |
+LLL |     pub fn query<Q: Query<T>, T>(&self, f: Q) {
+    |                     ^^^^^^^^ required by this bound in `World::query`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/opt_as_first.rs
+++ b/tests/ui/opt_as_first.rs
@@ -6,13 +6,13 @@ fn optional_components() {
     world.spawn((1_u32,));
     world.spawn((10_u32, "foo"));
     let mut results = vec![];
-    world.query::<(&u32, Option<&&str>)>(|_, (i, s)| results.push((*i, s.map(|s| *s))));
+    world.query(|_, i: &u32, s: Option<&&str>| results.push((*i, s.map(|s| *s))));
     results.sort();
     assert_eq!(&results[..], &[(1, None), (10, Some("foo"))]);
 
     let mut results = vec![];
-    world.query::<(Option<&&str>, &u32)>(|_, (s, i)| results.push((*i, s.map(|s| *s))));
-    //~^ ERROR: `Option<&&str>` cannot be the first element of a query
+    world.query(|_, s: Option<&&str>, i: &u32| results.push((*i, s.map(|s| *s))));
+    //~^ ERROR: is not a valid query
     results.sort();
     assert_eq!(&results[..], &[(10, Some("foo"))]);
 }

--- a/tests/ui/opt_as_first.stderr
+++ b/tests/ui/opt_as_first.stderr
@@ -1,15 +1,18 @@
-error[E0277]: `Option<&&str>` cannot be the first element of a query
-  --> tests/ui/opt_as_first.rs:14:11
-   |
-LL |     world.query::<(Option<&&str>, &u32)>(|_, (s, i)| results.push((*i, s.map(|s| *s))));
-   |           ^^^^^
-   |
-   = help: the trait `secs::query::Always` is not implemented for `Option<&&str>`
-   = note: move another element to the front of the list
-   = help: the following other types implement trait `secs::query::Always`:
-             &T
-             &mut T
-   = note: required for `(Option<&&str>, &u32)` to implement `secs::query::Query`
+error[E0277]: `{closure@tests/ui/opt_as_first.rs:14:17: 14:47}` is not a valid query
+   --> tests/ui/opt_as_first.rs:14:17
+    |
+14  |     world.query(|_, s: Option<&&str>, i: &u32| results.push((*i, s.map(|s| *s))));
+    |           ----- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |           |
+    |           required by a bound introduced by this call
+    |
+    = help: the trait `secs::query::Query<_>` is not implemented for closure `{closure@tests/ui/opt_as_first.rs:14:17: 14:47}`
+    = note: only tuples with 1 or up to 5 elements can be used as queries
+note: required by a bound in `World::query`
+   --> $DIR/src/world.rs
+    |
+LLL |     pub fn query<Q: Query<T>, T>(&self, f: Q) {
+    |                     ^^^^^^^^ required by this bound in `World::query`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/too_many_tuple_elements.rs
+++ b/tests/ui/too_many_tuple_elements.rs
@@ -3,6 +3,18 @@ use secs::World;
 fn optional_components() {
     let world = World::default();
 
-    world.query::<(u32, i32, u8, i8, u64, i64, u16, i16, u128, i128)>(|_, ()| {});
-    //~^ ERROR: `(u32, i32, u8, i8, u64, i64, u16, i16, u128, i128)` is not a valid query
+    world.query(
+        |_,
+         //~^ ERROR: is not a valid query
+         _: &u32,
+         _: &i32,
+         _: &u8,
+         _: &i8,
+         _: &u64,
+         _: &i64,
+         _: &u16,
+         _: &i16,
+         _: &u128,
+         _: &i128| {},
+    );
 }

--- a/tests/ui/too_many_tuple_elements.stderr
+++ b/tests/ui/too_many_tuple_elements.stderr
@@ -1,17 +1,24 @@
-error[E0277]: `(u32, i32, u8, i8, u64, i64, u16, i16, u128, i128)` is not a valid query
- --> tests/ui/too_many_tuple_elements.rs:6:11
-  |
-L |     world.query::<(u32, i32, u8, i8, u64, i64, u16, i16, u128, i128)>(|_, ()| {});
-  |           ^^^^^
-  |
-  = help: the trait `secs::query::Query` is not implemented for `(u32, i32, u8, i8, u64, i64, u16, i16, u128, i128)`
-  = note: only tuples with 1 or up to 5 elements can be used as queries
-  = help: the following other types implement trait `secs::query::Query`:
-            (T, U)
-            (T, U, V)
-            (T, U, V, W)
-            (T, U, V, W, X)
-            (T,)
+error[E0277]: `{closure@tests/ui/too_many_tuple_elements.rs:7:9: 18:19}` is not a valid query
+   --> tests/ui/too_many_tuple_elements.rs:7:9
+    |
+6   |       world.query(
+    |             ----- required by a bound introduced by this call
+7   | /         |_,
+8   | |
+9   | |          _: &u32,
+10  | |          _: &i32,
+...   |
+17  | |          _: &u128,
+18  | |          _: &i128| {},
+    | |_____________________^
+    |
+    = help: the trait `secs::query::Query<_>` is not implemented for closure `{closure@tests/ui/too_many_tuple_elements.rs:7:9: 18:19}`
+    = note: only tuples with 1 or up to 5 elements can be used as queries
+note: required by a bound in `World::query`
+   --> $DIR/src/world.rs
+    |
+LLL |     pub fn query<Q: Query<T>, T>(&self, f: Q) {
+    |                     ^^^^^^^^ required by this bound in `World::query`
 
 error: aborting due to 1 previous error
 

--- a/ui_test_deps/Cargo.lock
+++ b/ui_test_deps/Cargo.lock
@@ -3,24 +3,6 @@
 version = 4
 
 [[package]]
-name = "autocfg"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "bitflags"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "elsa"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,72 +12,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.170"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
-
-[[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "secs"
 version = "0.1.0"
 dependencies = [
  "elsa",
- "parking_lot",
 ]
-
-[[package]]
-name = "smallvec"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "stable_deref_trait"
@@ -109,67 +30,3 @@ version = "0.1.0"
 dependencies = [
  "secs",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"


### PR DESCRIPTION
cool side effect: our dependency graph is now

```
secs v0.1.0 (C:\Users\oli\secs)
└── elsa v1.11.0
    └── stable_deref_trait v1.2.0
```

instead of

```
secs v0.1.0 (C:\Users\oli\secs)
├── elsa v1.11.0
│   └── stable_deref_trait v1.2.0
└── parking_lot v0.12.3
    ├── lock_api v0.4.12
    │   └── scopeguard v1.2.0
    │   [build-dependencies]
    │   └── autocfg v1.4.0
    └── parking_lot_core v0.9.10
        ├── cfg-if v1.0.0
        ├── smallvec v1.14.0
        └── windows-targets v0.52.6
            └── windows_x86_64_msvc v0.52.6
```